### PR TITLE
Candidate ID was not being set when calling RequestVote callbacks

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -426,6 +426,7 @@ int raft_send_requestvote(raft_server_t* me_, int node)
     rv.term = me->current_term;
     rv.last_log_idx = raft_get_current_idx(me_);
     rv.last_log_term = raft_get_current_term(me_);
+    rv.candidate_id = raft_get_nodeid(me_);
     if (me->cb.send_requestvote)
         me->cb.send_requestvote(me_, me->udata, node, &rv);
     return 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1283,7 +1283,7 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
 
     sender = sender_new(NULL);
     r = raft_new();
-    raft_set_configuration(r, cfg, 0);
+    raft_set_configuration(r, cfg, 99);
     raft_set_state(r, RAFT_STATE_CANDIDATE);
 
     raft_set_callbacks(r, &funcs, sender);
@@ -1296,6 +1296,7 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
     CuAssertTrue(tc, 3 == rv->last_log_idx);
     CuAssertTrue(tc, 5 == rv->term);
     CuAssertTrue(tc, 5 == rv->last_log_term);
+    CuAssertTrue(tc, 99 == rv->candidate_id);
 }
 
 /* Candidate 5.2 */


### PR DESCRIPTION
Hi,
The candidate ID was not being set when RequestVote callbacks were being made. This caused the node to always claim to be node 0.

Unfortunately I can't add test cases as I can't get the test suite to run, it dies with:

    tests/main_test.c:8:8: error: unknown type name ‘Binary’
        extern Binary file (CuTest*);
     
Cheers,

Pete
