### PR TITLE
raft_server: fixed type mismatch on allocations

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -810,7 +810,7 @@ raft_node_t* raft_add_node(raft_server_t* me_, void* udata, int id, int is_self)
     }
 
     me->num_nodes++;
-    me->nodes = (raft_node_t*)realloc(me->nodes, sizeof(raft_node_t*) * me->num_nodes);
+    me->nodes = (raft_node_t*)realloc(me->nodes, sizeof(raft_node_t) * me->num_nodes);
     me->nodes[me->num_nodes - 1] = raft_node_new(udata, id);
     assert(me->nodes[me->num_nodes - 1]);
     if (is_self)
@@ -837,7 +837,7 @@ void raft_remove_node(raft_server_t* me_, raft_node_t* node)
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
     raft_node_t* new_array, *new_nodes;
-    new_array = (raft_node_t*)calloc((me->num_nodes - 1), sizeof(raft_node_t*));
+    new_array = (raft_node_t*)calloc((me->num_nodes - 1), sizeof(raft_node_t));
     new_nodes = new_array;
 
     int i, found = 0;


### PR DESCRIPTION
This was found using scan-build. Most likely it would not cause any
problems because `(void**)` is the same size as `(void*)`.