### PR TITLE
raft_node: parenthesized macro values

### DIFF
--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -16,9 +16,9 @@
 
 #include "raft.h"
 
-#define RAFT_NODE_VOTED_FOR_ME 1
-#define RAFT_NODE_VOTING 1 << 1
-#define RAFT_NODE_HAS_SUFFICIENT_LOG 1 << 2
+#define RAFT_NODE_VOTED_FOR_ME       1
+#define RAFT_NODE_VOTING             (1 << 1)
+#define RAFT_NODE_HAS_SUFFICIENT_LOG (1 << 2)
 
 typedef struct
 {


### PR DESCRIPTION
This fixes the build in clang due to a bitwise inversion ambiguity.