### PR TITLE
Avoid expensive console log formatting if possible.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ LLQUEUE_DIR = $(CONTRIB_DIR)/CLinkedListQueue
 VPATH = src
 
 GCOV_OUTPUT = *.gcda *.gcno *.gcov 
-GCOV_CCFLAGS = -fprofile-arcs -ftest-coverage
+#GCOV_CCFLAGS = -fprofile-arcs -ftest-coverage
+GCOV_CCFLAGS =
 SHELL  = /bin/bash
 CFLAGS += -Iinclude -Werror -Werror=return-type -Werror=uninitialized -Wcast-align \
 	  -Wno-pointer-sign -fno-omit-frame-pointer -fno-common -fsigned-char \
 	  -Wunused-variable \
-	  $(GCOV_CCFLAGS) -I$(LLQUEUE_DIR) -Iinclude -g -O2 -fPIC
+	  $(GCOV_CCFLAGS) -I$(LLQUEUE_DIR) -Iinclude -g -O3 -fPIC -march=native
 
 UNAME := $(shell uname)
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,5 @@
+mkdir -p /usr/local/include/raft
+sudo cp $(dirname $0)/include/raft.h /usr/local/include/raft/
+sudo cp $(dirname $0)/libcraft.* /usr/local/lib
+sudo ldconfig
+

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-mkdir -p /usr/local/include/raft
+sudo mkdir -p /usr/local/include/raft
 sudo cp $(dirname $0)/include/raft.h /usr/local/include/raft/
 sudo cp $(dirname $0)/libcraft.* /usr/local/lib
 sudo ldconfig

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -31,14 +31,14 @@
 static void __log(raft_server_t *me_, raft_node_t* node, const char *fmt, ...)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
+    if (me->cb.log == NULL) return;
     char buf[1024];
     va_list args;
 
     va_start(args, fmt);
     vsprintf(buf, fmt, args);
 
-    if (me->cb.log)
-        me->cb.log(me_, node, me->udata, buf);
+    me->cb.log(me_, node, me->udata, buf);
 }
 
 raft_server_t* raft_new()


### PR DESCRIPTION
The call to `__log()` adds 1--2 microseconds of overhead, which is substantial when the network is fast (e.g., RDMA).