### PR TITLE
DAOS-333 server: Fix recv AE response return code

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -230,7 +230,7 @@ int raft_recv_appendentries_response(raft_server_t* me_,
         return 0;
 
     if (!raft_is_leader(me_))
-        return -1;
+        return RAFT_ERR_NOT_LEADER;
 
     /* If response contains term T > currentTerm: set currentTerm = T
        and convert to follower (§5.3) */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3074,7 +3074,7 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
     aer.success = 1;
     aer.current_idx = 1;
     aer.first_idx = 1;
-    CuAssertTrue(tc, -1 == raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer));
+    CuAssertTrue(tc, RAFT_ERR_NOT_LEADER == raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer));
     CuAssertTrue(tc, NULL == sender_poll_msg_data(sender));
 }
 


### PR DESCRIPTION
When the calling replica isn't in the leader state,
raft_recv_appendentries_response() should return RAFT_ERR_NOT_LEADER
instead of -1.

Signed-off-by: Li Wei <wei.g.li@intel.com>