### PR TITLE
DAOS-333 server: Persist term and vote atomically

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -223,14 +223,31 @@ typedef void (
  * For safety reasons this callback MUST flush the change to disk.
  * @param[in] raft The Raft server making this callback
  * @param[in] user_data User data that is passed from Raft server
- * @param[in] voted_for The node we voted for
+ * @param[in] vote The node we voted for
  * @return 0 on success */
 typedef int (
-*func_persist_int_f
+*func_persist_vote_f
 )   (
     raft_server_t* raft,
     void *user_data,
-    int node
+    int vote
+    );
+
+/** Callback for saving current term (and nil vote) to disk.
+ * For safety reasons this callback MUST flush the term and vote changes to
+ * disk atomically.
+ * @param[in] raft The Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @param[in] term Current term
+ * @param[in] vote The node value dicating we haven't voted for anybody
+ * @return 0 on success */
+typedef int (
+*func_persist_term_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    int term,
+    int vote
     );
 
 /** Callback for saving log entry changes.
@@ -277,11 +294,12 @@ typedef struct
 
     /** Callback for persisting vote data
      * For safety reasons this callback MUST flush the change to disk. */
-    func_persist_int_f persist_vote;
+    func_persist_vote_f persist_vote;
 
-    /** Callback for persisting term data
-     * For safety reasons this callback MUST flush the change to disk. */
-    func_persist_int_f persist_term;
+    /** Callback for persisting term (and nil vote) data
+     * For safety reasons this callback MUST flush the term and vote changes to
+     * disk atomically. */
+    func_persist_term_f persist_term;
 
     /** Callback for adding an entry to the log
      * For safety reasons this callback MUST flush the change to disk.

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -89,7 +89,7 @@ void raft_set_current_term(raft_server_t* me_, const int term)
         me->current_term = term;
         me->voted_for = -1;
         assert(me->cb.persist_term);
-        me->cb.persist_term(me_, me->udata, term);
+        me->cb.persist_term(me_, me->udata, term, me->voted_for);
     }
 }
 

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -14,7 +14,8 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    const int val
+    int term,
+    int vote
     )
 {
     return 0;
@@ -23,7 +24,7 @@ static int __raft_persist_term(
 static int __raft_persist_vote(
     raft_server_t* raft,
     void *udata,
-    const int val
+    int vote
     )
 {
     return 0;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -18,7 +18,8 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    const int val
+    int term,
+    int vote
     )
 {
     return 0;
@@ -27,7 +28,7 @@ static int __raft_persist_term(
 static int __raft_persist_vote(
     raft_server_t* raft,
     void *udata,
-    const int val
+    int vote
     )
 {
     return 0;


### PR DESCRIPTION
Remind users' persist_term implementations to persist currentTerm and
nil votedFor atomically.

Signed-off-by: Li Wei <wei.g.li@intel.com>