### PR TITLE
Try to apply all committed entries in raft_periodic().

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -236,7 +236,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
     if (me->last_applied_idx < raft_get_commit_idx(me_) &&
         !raft_snapshot_is_in_progress(me_))
     {
-        int e = raft_apply_entry(me_);
+        int e = raft_apply_all(me_);
         if (-1 != e)
             return e;
     }


### PR DESCRIPTION
I have noticed that entries accumulate in the log and only get applied in the rate of calling `raft_periodic()`.  This greatly improves write rate, and as far as I can tell should not break anything.

Perhaps a future improvement can add a cap on the number of entries (or even time) per periodic call to prevent starvation of other parts of the event loop.