### PR TITLE
Remove duplicate raft_get_last_applied_entry().

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -765,8 +765,6 @@ int raft_entry_is_voting_cfg_change(raft_entry_t* ety);
  * @return 1 if this is a configuration change. */
 int raft_entry_is_cfg_change(raft_entry_t* ety);
 
-raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_);
-
 /** Begin snapshotting.
  *
  * While snapshotting, raft will:


### PR DESCRIPTION
This fails the fuzzer tests.