### PR TITLE
Add custom heap management hooks.

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -870,4 +870,13 @@ int raft_node_is_voting_committed(raft_node_t* me_);
  **/
 int raft_node_is_addition_committed(raft_node_t* me_);
 
+/**
+ * Register custom heap management functions, to be used if an alternative
+ * heap management is used.
+ **/
+void raft_set_heap_functions(void *(*_malloc)(size_t),
+                             void *(*_calloc)(size_t, size_t),
+                             void *(*_realloc)(void *, size_t),
+                             void (*_free)(void *));
+
 #endif /* RAFT_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -136,6 +136,12 @@ int raft_node_is_active(raft_node_t* me_);
 
 void raft_node_set_voting_committed(raft_node_t* me_, int voting);
 
-int raft_node_set_addition_committed(raft_node_t* me_, int committed);
+void raft_node_set_addition_committed(raft_node_t* me_, int committed);
+
+/* Heap functions */
+extern void *(*__raft_malloc)(size_t size);
+extern void *(*__raft_calloc)(size_t nmemb, size_t size);
+extern void *(*__raft_realloc)(void *ptr, size_t size);
+extern void (*__raft_free)(void *ptr);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -54,7 +54,7 @@ static int __ensurecapacity(log_private_t * me)
     if (me->count < me->size)
         return 0;
 
-    temp = (raft_entry_t*)calloc(1, sizeof(raft_entry_t) * me->size * 2);
+    temp = (raft_entry_t*)__raft_calloc(1, sizeof(raft_entry_t) * me->size * 2);
     if (!temp)
         return RAFT_ERR_NOMEM;
 
@@ -66,7 +66,7 @@ static int __ensurecapacity(log_private_t * me)
     }
 
     /* clean up old entries */
-    free(me->entries);
+    __raft_free(me->entries);
 
     me->size *= 2;
     me->entries = temp;
@@ -101,14 +101,14 @@ int log_load_from_snapshot(log_t *me_, int idx, int term)
 
 log_t* log_alloc(int initial_size)
 {
-    log_private_t* me = (log_private_t*)calloc(1, sizeof(log_private_t));
+    log_private_t* me = (log_private_t*)__raft_calloc(1, sizeof(log_private_t));
     if (!me)
         return NULL;
     me->size = initial_size;
     log_clear((log_t*)me);
-    me->entries = (raft_entry_t*)calloc(1, sizeof(raft_entry_t) * me->size);
+    me->entries = (raft_entry_t*)__raft_calloc(1, sizeof(raft_entry_t) * me->size);
     if (!me->entries) {
-        free(me);
+        __raft_free(me);
         return NULL;
     }
     return (log_t*)me;
@@ -300,8 +300,8 @@ void log_free(log_t * me_)
 {
     log_private_t* me = (log_private_t*)me_;
 
-    free(me->entries);
-    free(me);
+    __raft_free(me->entries);
+    __raft_free(me);
 }
 
 int log_get_current_idx(log_t* me_)

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 
 #include "raft.h"
+#include "raft_private.h"
 
 #define RAFT_NODE_VOTED_FOR_ME        (1 << 0)
 #define RAFT_NODE_VOTING              (1 << 1)
@@ -38,7 +39,7 @@ typedef struct
 raft_node_t* raft_node_new(void* udata, int id)
 {
     raft_node_private_t* me;
-    me = (raft_node_private_t*)calloc(1, sizeof(raft_node_private_t));
+    me = (raft_node_private_t*)__raft_calloc(1, sizeof(raft_node_private_t));
     if (!me)
         return NULL;
     me->udata = udata;
@@ -51,7 +52,7 @@ raft_node_t* raft_node_new(void* udata, int id)
 
 void raft_node_free(raft_node_t* me_)
 {
-    free(me_);
+    __raft_free(me_);
 }
 
 int raft_node_get_next_idx(raft_node_t* me_)


### PR DESCRIPTION
Useful when using the library along with custom memory allocation libraries such as jemalloc or tcmalloc, if the original malloc/free/etc. symbols are not overwritten.