### PR TITLE
Add a per-entry custom user data field.

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -89,6 +89,9 @@ typedef struct
     /** type of entry */
     int type;
 
+    /** private local data */
+    void *user_data;
+
     raft_entry_data_t data;
 } raft_entry_t;
 


### PR DESCRIPTION
This is useful to allow leaders to pass context between
raft_recv_entry() and a subsequent execution of the entry (after it was
committed) as an applylog callback.

This allows an optimized use pattern when entries received locally on
the leader can be used without going through an unnecessary
deserialization.