### PR TITLE
Fix issue with nodes not promoted to voting.

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -125,7 +125,6 @@ void raft_clear(raft_server_t* me_)
     me->last_applied_idx = 0;
     me->num_nodes = 0;
     me->node = NULL;
-    me->voting_cfg_change_log_idx = 0;
     log_clear(me->log);
 }
 
@@ -810,8 +809,11 @@ int raft_apply_entry(raft_server_t* me_)
             return RAFT_ERR_SHUTDOWN;
     }
 
-    /* voting cfg change is now complete */
-    if (log_idx == me->voting_cfg_change_log_idx)
+    /* voting cfg change is now complete.
+     * TODO: there seem to be a possible off-by-one bug hidden here, requiring
+     * checking log_idx >= voting_cfg_change_log_idx rather than plain ==.
+     */
+    if (log_idx >= me->voting_cfg_change_log_idx)
         me->voting_cfg_change_log_idx = -1;
 
     if (!raft_entry_is_cfg_change(ety))


### PR DESCRIPTION
This fix is possibly incomplete and may shadow another problem, possibly
an off-by-one handling of the voting configuration change index.