### PR TITLE
Fix fuzz test issue with python 3.x.

### DIFF
--- a/tests/log_fuzzer.py
+++ b/tests/log_fuzzer.py
@@ -28,7 +28,10 @@ class Libraft(object):
         self.lib = ffi.dlopen(library)
 
         def load(fname):
-            return subprocess.check_output(["gcc", "-E", fname])
+            return '\n'.join(
+                [line for line in subprocess.check_output(
+                    ["gcc", "-E", fname]).decode('utf-8').split('\n')
+                 if not line.startswith('#')])
 
         ffi.cdef(load('include/raft.h'))
         ffi.cdef(load('include/raft_log.h'))


### PR DESCRIPTION
Python 3.x's `check_output()` returns a byte array which needs to be decoded as CFFI expects a string.
I then noticed that (newer versions of?) `CFFI.cdef()` fail to deal with `#` lines injected by the preprocessor and they must be filtered out.