### PR TITLE
Term and index values should have their own type

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -405,7 +405,7 @@ typedef struct
  * Election timeout defaults to 1000 milliseconds
  *
  * @return newly initialised Raft server */
-raft_server_t* raft_new();
+raft_server_t* raft_new(void);
 
 /** De-initialise Raft server.
  * Frees all memory */

--- a/include/raft.h
+++ b/include/raft.h
@@ -10,6 +10,8 @@
 #ifndef RAFT_H_
 #define RAFT_H_
 
+#include "raft_types.h"
+
 #define RAFT_ERR_NOT_LEADER                  -2
 #define RAFT_ERR_ONE_VOTING_CHANGE_ONLY      -3
 #define RAFT_ERR_SHUTDOWN                    -4
@@ -81,10 +83,10 @@ typedef struct
 typedef struct
 {
     /** the entry's term at the point it was created */
-    unsigned int term;
+    raft_term_t term;
 
     /** the entry's unique ID */
-    unsigned int id;
+    raft_entry_id_t id;
 
     /** type of entry */
     int type;
@@ -102,13 +104,13 @@ typedef raft_entry_t msg_entry_t;
 typedef struct
 {
     /** the entry's unique ID */
-    unsigned int id;
+    raft_entry_id_t id;
 
     /** the entry's term */
-    int term;
+    raft_term_t term;
 
     /** the entry's index */
-    int idx;
+    raft_index_t idx;
 } msg_entry_response_t;
 
 /** Vote request message.
@@ -117,16 +119,16 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** candidate requesting vote */
-    int candidate_id;
+    raft_node_id_t candidate_id;
 
     /** index of candidate's last log entry */
-    int last_log_idx;
+    raft_index_t last_log_idx;
 
     /** term of candidate's last log entry */
-    int last_log_term;
+    raft_term_t last_log_term;
 } msg_requestvote_t;
 
 /** Vote request response message.
@@ -134,7 +136,7 @@ typedef struct
 typedef struct
 {
     /** currentTerm, for candidate to update itself */
-    int term;
+    raft_term_t term;
 
     /** true means candidate received vote */
     int vote_granted;
@@ -147,19 +149,19 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** the index of the log just before the newest entry for the node who
      * receives this message */
-    int prev_log_idx;
+    raft_index_t prev_log_idx;
 
     /** the term of the log just before the newest entry for the node who
      * receives this message */
-    int prev_log_term;
+    raft_term_t prev_log_term;
 
     /** the index of the entry that has been appended to the majority of the
      * cluster. Entries up to this index will be applied to the FSM */
-    int leader_commit;
+    raft_index_t leader_commit;
 
     /** number of entries within this message */
     int n_entries;
@@ -174,7 +176,7 @@ typedef struct
 typedef struct
 {
     /** currentTerm, to force other leader/candidate to step down */
-    int term;
+    raft_term_t term;
 
     /** true if follower contained entry matching prevLogidx and prevLogTerm */
     int success;
@@ -185,10 +187,10 @@ typedef struct
 
     /** If success, this is the highest log IDX we've received and appended to
      * our log; otherwise, this is the our currentIndex */
-    int current_idx;
+    raft_index_t current_idx;
 
     /** The first idx that we received within the appendentries message */
-    int first_idx;
+    raft_index_t first_idx;
 } msg_appendentries_response_t;
 
 typedef void* raft_server_t;
@@ -283,7 +285,7 @@ typedef int (
 )   (
     raft_server_t* raft,
     void *user_data,
-    int vote
+    raft_node_id_t vote
     );
 
 /** Callback for saving current term (and nil vote) to disk.
@@ -299,8 +301,8 @@ typedef int (
 )   (
     raft_server_t* raft,
     void *user_data,
-    int term,
-    int vote
+    raft_term_t term,
+    raft_node_id_t vote
     );
 
 /** Callback for saving log entry changes.
@@ -329,7 +331,7 @@ typedef int (
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    raft_index_t entry_idx
     );
 
 typedef struct
@@ -437,7 +439,7 @@ void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* user_data);
  * @return
  *  node if it was successfully added;
  *  NULL if the node already exists */
-raft_node_t* raft_add_node(raft_server_t* me, void* user_data, int id, int is_self);
+raft_node_t* raft_add_node(raft_server_t* me, void* user_data, raft_node_id_t id, int is_self);
 
 #define raft_add_peer raft_add_node
 
@@ -447,7 +449,7 @@ raft_node_t* raft_add_node(raft_server_t* me, void* user_data, int id, int is_se
  * @return
  *  node if it was successfully added;
  *  NULL if the node already exists */
-raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, int id, int is_self);
+raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self);
 
 /** Remove node.
  * @param node The node to be removed. */
@@ -583,19 +585,19 @@ int raft_get_num_voting_nodes(raft_server_t* me_);
 
 /**
  * @return number of items within log */
-int raft_get_log_count(raft_server_t* me);
+raft_index_t raft_get_log_count(raft_server_t* me);
 
 /**
  * @return current term */
-int raft_get_current_term(raft_server_t* me);
+raft_term_t raft_get_current_term(raft_server_t* me);
 
 /**
  * @return current log index */
-int raft_get_current_idx(raft_server_t* me);
+raft_index_t raft_get_current_idx(raft_server_t* me);
 
 /**
  * @return commit index */
-int raft_get_commit_idx(raft_server_t* me_);
+raft_index_t raft_get_commit_idx(raft_server_t* me_);
 
 /**
  * @return 1 if follower; 0 otherwise */
@@ -619,15 +621,15 @@ int raft_get_request_timeout(raft_server_t* me);
 
 /**
  * @return index of last applied entry */
-int raft_get_last_applied_idx(raft_server_t* me);
+raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 
 /**
  * @return the node's next index */
-int raft_node_get_next_idx(raft_node_t* node);
+raft_index_t raft_node_get_next_idx(raft_node_t* node);
 
 /**
  * @return this node's user data */
-int raft_node_get_match_idx(raft_node_t* me);
+raft_index_t raft_node_get_match_idx(raft_node_t* me);
 
 /**
  * @return this node's user data */
@@ -640,18 +642,18 @@ void raft_node_set_udata(raft_node_t* me, void* user_data);
 /**
  * @param[in] idx The entry's index
  * @return entry from index */
-raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, int idx);
+raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
 
 /**
  * @param[in] node The node's ID
  * @return node pointed to by node ID */
-raft_node_t* raft_get_node(raft_server_t* me_, const int id);
+raft_node_t* raft_get_node(raft_server_t* me_, const raft_node_id_t id);
 
 /**
  * Used for iterating through nodes
  * @param[in] node The node's idx
  * @return node pointed to by node idx */
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const int idx);
+raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx);
 
 /**
  * @return number of votes this server has received this election */
@@ -664,7 +666,7 @@ int raft_get_voted_for(raft_server_t* me);
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   -1 if the leader is unknown */
-int raft_get_current_leader(raft_server_t* me);
+raft_node_id_t raft_get_current_leader(raft_server_t* me);
 
 /** Get what this node thinks the node of the leader is.
  * @return node of what this node thinks is the valid leader;
@@ -687,19 +689,19 @@ int raft_vote(raft_server_t* me_, raft_node_t* node);
  * @param[in] nodeid The server to vote for by nodeid
  * @return
  *  0 on success */
-int raft_vote_for_nodeid(raft_server_t* me_, const int nodeid);
+int raft_vote_for_nodeid(raft_server_t* me_, const raft_node_id_t nodeid);
 
 /** Set the current term.
  * This should be used to reload persistent state, ie. the current_term field.
  * @param[in] term The new current term
  * @return
  *  0 on success */
-int raft_set_current_term(raft_server_t* me, const int term);
+int raft_set_current_term(raft_server_t* me, const raft_term_t term);
 
 /** Set the commit idx.
  * This should be used to reload persistent state, ie. the commit_idx field.
  * @param[in] commit_idx The new commit index. */
-void raft_set_commit_idx(raft_server_t* me, int commit_idx);
+void raft_set_commit_idx(raft_server_t* me, raft_index_t commit_idx);
 
 /** Add an entry to the server's log.
  * This should be used to reload persistent state, ie. the commit log.
@@ -717,7 +719,7 @@ int raft_msg_entry_response_committed(raft_server_t* me_,
 
 /** Get node's ID.
  * @return ID of node */
-int raft_node_get_id(raft_node_t* me_);
+raft_node_id_t raft_node_get_id(raft_node_t* me_);
 
 /** Tell if we are a leader, candidate or follower.
  * @return get state of type raft_state_e. */
@@ -725,7 +727,7 @@ int raft_get_state(raft_server_t* me_);
 
 /** The the most recent log's term
  * @return the last log term */
-int raft_get_last_log_term(raft_server_t* me_);
+raft_term_t raft_get_last_log_term(raft_server_t* me_);
 
 /** Turn a node into a voting node.
  * Voting nodes can take part in elections and in-regards to commiting entries,
@@ -794,7 +796,7 @@ int raft_end_snapshot(raft_server_t *me_);
 
 /** Get the entry index of the entry that was snapshotted
  **/
-int raft_get_snapshot_entry_idx(raft_server_t *me_);
+raft_index_t raft_get_snapshot_entry_idx(raft_server_t *me_);
 
 /** Check is a snapshot is in progress
  **/
@@ -810,7 +812,7 @@ int raft_poll_entry(raft_server_t* me_, raft_entry_t **ety);
  **/
 raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_);
 
-int raft_get_first_entry_idx(raft_server_t* me_);
+raft_index_t raft_get_first_entry_idx(raft_server_t* me_);
 
 /** Start loading snapshot
  *
@@ -826,8 +828,8 @@ int raft_get_first_entry_idx(raft_server_t* me_);
  *  RAFT_ERR_SNAPSHOT_ALREADY_LOADED
  **/
 int raft_begin_load_snapshot(raft_server_t *me_,
-                       int last_included_term,
-		       int last_included_index);
+                       raft_term_t last_included_term,
+		       raft_index_t last_included_index);
 
 /** Stop loading snapshot.
  *
@@ -837,11 +839,11 @@ int raft_begin_load_snapshot(raft_server_t *me_,
  **/
 int raft_end_load_snapshot(raft_server_t *me_);
 
-int raft_get_snapshot_last_idx(raft_server_t *me_);
+raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_);
 
-int raft_get_snapshot_last_term(raft_server_t *me_);
+raft_term_t raft_get_snapshot_last_term(raft_server_t *me_);
 
-void raft_set_snapshot_metadata(raft_server_t *me_, int term, int idx);
+void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx);
 
 /** Check if a node is active.
  * Active nodes could become voting nodes.

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -1,11 +1,13 @@
 #ifndef RAFT_LOG_H_
 #define RAFT_LOG_H_
 
+#include "raft_types.h"
+
 typedef void* log_t;
 
-log_t* log_new();
+log_t* log_new(void);
 
-log_t* log_alloc(int initial_size);
+log_t* log_alloc(raft_index_t initial_size);
 
 void log_set_callbacks(log_t* me_, raft_cbs_t* funcs, void* raft);
 
@@ -22,11 +24,11 @@ int log_append_entry(log_t* me_, raft_entry_t* c);
 
 /**
  * @return number of entries held within log */
-int log_count(log_t* me_);
+raft_index_t log_count(log_t* me_);
 
 /**
  * Delete all logs from this log onwards */
-int log_delete(log_t* me_, int idx);
+int log_delete(log_t* me_, raft_index_t idx);
 
 /**
  * Empty the queue. */
@@ -39,18 +41,18 @@ int log_poll(log_t * me_, void** etyp);
 /** Get an array of entries from this index onwards.
  * This is used for batching.
  */
-raft_entry_t* log_get_from_idx(log_t* me_, int idx, int *n_etys);
+raft_entry_t* log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys);
 
-raft_entry_t* log_get_at_idx(log_t* me_, int idx);
+raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx);
 
 /**
  * @return youngest entry */
 raft_entry_t *log_peektail(log_t * me_);
 
-int log_get_current_idx(log_t* me_);
+raft_index_t log_get_current_idx(log_t* me_);
 
-int log_load_from_snapshot(log_t *me_, int idx, int term);
+int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term);
 
-int log_get_base(log_t* me_);
+raft_index_t log_get_base(log_t* me_);
 
 #endif /* RAFT_LOG_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -10,6 +10,8 @@
 #ifndef RAFT_PRIVATE_H_
 #define RAFT_PRIVATE_H_
 
+#include "raft_types.h"
+
 enum {
     RAFT_NODE_STATUS_DISCONNECTED,
     RAFT_NODE_STATUS_CONNECTED,
@@ -22,11 +24,11 @@ typedef struct {
 
     /* the server's best guess of what the current term is
      * starts at zero */
-    int current_term;
+    raft_term_t current_term;
 
     /* The candidate the server voted for in its current term,
      * or Nil if it hasn't voted for any.  */
-    int voted_for;
+    raft_node_id_t voted_for;
 
     /* the log which is replicated */
     void* log;
@@ -34,10 +36,10 @@ typedef struct {
     /* Volatile state: */
 
     /* idx of highest log entry known to be committed */
-    int commit_idx;
+    raft_index_t commit_idx;
 
     /* idx of highest log entry applied to state machine */
-    int last_applied_idx;
+    raft_index_t last_applied_idx;
 
     /* follower/leader/candidate indicator */
     int state;
@@ -64,7 +66,7 @@ typedef struct {
     raft_node_t* node;
 
     /* the log which has a voting cfg change, otherwise -1 */
-    int voting_cfg_change_log_idx;
+    raft_index_t voting_cfg_change_log_idx;
 
     /* Our membership with the cluster is confirmed (ie. configuration log was
      * committed) */
@@ -73,8 +75,8 @@ typedef struct {
     int snapshot_in_progress;
 
     /* Last compacted snapshot */
-    int snapshot_last_idx;
-    int snapshot_last_term;
+    raft_index_t snapshot_last_idx;
+    raft_term_t snapshot_last_term;
 } raft_server_private_t;
 
 int raft_election_start(raft_server_t* me);
@@ -102,21 +104,21 @@ int raft_apply_entry(raft_server_t* me_);
  * @return 0 if unsuccessful */
 int raft_append_entry(raft_server_t* me_, raft_entry_t* c);
 
-void raft_set_last_applied_idx(raft_server_t* me, int idx);
+void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx);
 
 void raft_set_state(raft_server_t* me_, int state);
 
 int raft_get_state(raft_server_t* me_);
 
-raft_node_t* raft_node_new(void* udata, int id);
+raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
-void raft_node_set_next_idx(raft_node_t* node, int nextIdx);
+void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
 
-void raft_node_set_match_idx(raft_node_t* node, int matchIdx);
+void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
 
-int raft_node_get_match_idx(raft_node_t* me_);
+raft_index_t raft_node_get_match_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 
@@ -126,11 +128,11 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 
-void raft_offer_log(raft_server_t* me_, raft_entry_t* ety, const int idx);
+void raft_offer_log(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
 
-void raft_pop_log(raft_server_t* me_, raft_entry_t* ety, const int idx);
+void raft_pop_log(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
 
-int raft_get_num_snapshottable_logs(raft_server_t* me_);
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
 int raft_node_is_active(raft_node_t* me_);
 

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -1,0 +1,28 @@
+
+#ifndef RAFT_DEFS_H_
+#define RAFT_DEFS_H_
+
+/**
+ * Unique entry ids are mostly used for debugging and nothing else,
+ * so there is little harm if they collide.
+ */
+typedef int raft_entry_id_t;
+
+/**
+ * Monotonic term counter.
+ */
+typedef long int raft_term_t;
+
+/**
+ * Monotonic log entry index.
+ *
+ * This is also used to as an entry count size type.
+ */
+typedef long int raft_index_t;
+
+/**
+ * Unique node identifier.
+ */
+typedef int raft_node_id_t;
+
+#endif  /* RAFT_DEFS_H_ */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -114,7 +114,7 @@ log_t* log_alloc(raft_index_t initial_size)
     return (log_t*)me;
 }
 
-log_t* log_new()
+log_t* log_new(void)
 {
     return log_alloc(INITIAL_CAPACITY);
 }

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -22,16 +22,16 @@
 typedef struct
 {
     /* size of array */
-    int size;
+    raft_index_t size;
 
     /* the amount of elements in the array */
-    int count;
+    raft_index_t count;
 
     /* position of the queue */
-    int front, back;
+    raft_index_t front, back;
 
     /* we compact the log, and thus need to increment the Base Log Index */
-    int base;
+    raft_index_t base;
 
     raft_entry_t* entries;
 
@@ -40,7 +40,7 @@ typedef struct
     void* raft;
 } log_private_t;
 
-static int mod(int a, int b)
+static int mod(raft_index_t a, raft_index_t b)
 {
     int r = a % b;
     return r < 0 ? r + b : r;
@@ -48,7 +48,7 @@ static int mod(int a, int b)
 
 static int __ensurecapacity(log_private_t * me)
 {
-    int i, j;
+    raft_index_t i, j;
     raft_entry_t *temp;
 
     if (me->count < me->size)
@@ -75,7 +75,7 @@ static int __ensurecapacity(log_private_t * me)
     return 0;
 }
 
-int log_load_from_snapshot(log_t *me_, int idx, int term)
+int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term)
 {
     log_private_t* me = (log_private_t*)me_;
 
@@ -99,7 +99,7 @@ int log_load_from_snapshot(log_t *me_, int idx, int term)
     return 0;
 }
 
-log_t* log_alloc(int initial_size)
+log_t* log_alloc(raft_index_t initial_size)
 {
     log_private_t* me = (log_private_t*)__raft_calloc(1, sizeof(log_private_t));
     if (!me)
@@ -140,7 +140,7 @@ void log_clear(log_t* me_)
 int log_append_entry(log_t* me_, raft_entry_t* ety)
 {
     log_private_t* me = (log_private_t*)me_;
-    int idx = me->base + me->count + 1;
+    raft_index_t idx = me->base + me->count + 1;
     int e;
 
     e = __ensurecapacity(me);
@@ -165,10 +165,10 @@ int log_append_entry(log_t* me_, raft_entry_t* ety)
     return 0;
 }
 
-raft_entry_t* log_get_from_idx(log_t* me_, int idx, int *n_etys)
+raft_entry_t* log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys)
 {
     log_private_t* me = (log_private_t*)me_;
-    int i;
+    raft_index_t i;
 
     assert(0 <= idx - 1);
 
@@ -194,10 +194,10 @@ raft_entry_t* log_get_from_idx(log_t* me_, int idx, int *n_etys)
     return &me->entries[i];
 }
 
-raft_entry_t* log_get_at_idx(log_t* me_, int idx)
+raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx)
 {
     log_private_t* me = (log_private_t*)me_;
-    int i;
+    raft_index_t i;
 
     if (idx == 0)
         return NULL;
@@ -215,12 +215,12 @@ raft_entry_t* log_get_at_idx(log_t* me_, int idx)
     return &me->entries[i];
 }
 
-int log_count(log_t* me_)
+raft_index_t log_count(log_t* me_)
 {
     return ((log_private_t*)me_)->count;
 }
 
-int log_delete(log_t* me_, int idx)
+int log_delete(log_t* me_, raft_index_t idx)
 {
     log_private_t* me = (log_private_t*)me_;
 
@@ -232,8 +232,8 @@ int log_delete(log_t* me_, int idx)
 
     for (; idx <= me->base + me->count && me->count;)
     {
-        int idx_tmp = me->base + me->count;
-        int back = mod(me->back - 1, me->size);
+        raft_index_t idx_tmp = me->base + me->count;
+        raft_index_t back = mod(me->back - 1, me->size);
 
         if (me->cb && me->cb->log_pop)
         {
@@ -252,7 +252,7 @@ int log_delete(log_t* me_, int idx)
 int log_poll(log_t * me_, void** etyp)
 {
     log_private_t* me = (log_private_t*)me_;
-    int idx = me->base + 1;
+    raft_index_t idx = me->base + 1;
 
     if (0 == me->count)
         return -1;
@@ -304,13 +304,13 @@ void log_free(log_t * me_)
     __raft_free(me);
 }
 
-int log_get_current_idx(log_t* me_)
+raft_index_t log_get_current_idx(log_t* me_)
 {
     log_private_t* me = (log_private_t*)me_;
     return log_count(me_) + me->base;
 }
 
-int log_get_base(log_t* me_)
+raft_index_t log_get_base(log_t* me_)
 {
     return ((log_private_t*)me_)->base;
 }

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -28,15 +28,15 @@ typedef struct
 {
     void* udata;
 
-    int next_idx;
-    int match_idx;
+    raft_index_t next_idx;
+    raft_index_t match_idx;
 
     int flags;
 
-    int id;
+    raft_node_id_t id;
 } raft_node_private_t;
 
-raft_node_t* raft_node_new(void* udata, int id)
+raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
 {
     raft_node_private_t* me;
     me = (raft_node_private_t*)__raft_calloc(1, sizeof(raft_node_private_t));
@@ -55,26 +55,26 @@ void raft_node_free(raft_node_t* me_)
     __raft_free(me_);
 }
 
-int raft_node_get_next_idx(raft_node_t* me_)
+raft_index_t raft_node_get_next_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->next_idx;
 }
 
-void raft_node_set_next_idx(raft_node_t* me_, int nextIdx)
+void raft_node_set_next_idx(raft_node_t* me_, raft_index_t nextIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     /* log index begins at 1 */
     me->next_idx = nextIdx < 1 ? 1 : nextIdx;
 }
 
-int raft_node_get_match_idx(raft_node_t* me_)
+raft_index_t raft_node_get_match_idx(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->match_idx;
 }
 
-void raft_node_set_match_idx(raft_node_t* me_, int matchIdx)
+void raft_node_set_match_idx(raft_node_t* me_, raft_index_t matchIdx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     me->match_idx = matchIdx;
@@ -170,7 +170,7 @@ int raft_node_is_voting_committed(raft_node_t* me_)
     return (me->flags & RAFT_NODE_VOTING_COMMITTED) != 0;
 }
 
-int raft_node_get_id(raft_node_t* me_)
+raft_node_id_t raft_node_get_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->id;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -66,7 +66,7 @@ void raft_randomize_election_timeout(raft_server_t* me_)
     __log(me_, NULL, "randomize election timeout to %d", me->election_timeout_rand);
 }
 
-raft_server_t* raft_new()
+raft_server_t* raft_new(void)
 {
     raft_server_private_t* me =
         (raft_server_private_t*)__raft_calloc(1, sizeof(raft_server_private_t));

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -32,7 +32,7 @@ void raft_set_request_timeout(raft_server_t* me_, int millisec)
     me->request_timeout = millisec;
 }
 
-int raft_get_nodeid(raft_server_t* me_)
+raft_node_id_t raft_get_nodeid(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     if (!me->node)
@@ -70,7 +70,7 @@ int raft_get_timeout_elapsed(raft_server_t* me_)
     return ((raft_server_private_t*)me_)->timeout_elapsed;
 }
 
-int raft_get_log_count(raft_server_t* me_)
+raft_index_t raft_get_log_count(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return log_count(me->log);
@@ -82,7 +82,7 @@ int raft_get_voted_for(raft_server_t* me_)
     return me->voted_for;
 }
 
-int raft_set_current_term(raft_server_t* me_, const int term)
+int raft_set_current_term(raft_server_t* me_, const raft_term_t term)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     if (me->current_term < term)
@@ -100,18 +100,18 @@ int raft_set_current_term(raft_server_t* me_, const int term)
     return 0;
 }
 
-int raft_get_current_term(raft_server_t* me_)
+raft_term_t raft_get_current_term(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->current_term;
 }
 
-int raft_get_current_idx(raft_server_t* me_)
+raft_index_t raft_get_current_idx(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return log_get_current_idx(me->log);
 }
 
-void raft_set_commit_idx(raft_server_t* me_, int idx)
+void raft_set_commit_idx(raft_server_t* me_, raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     assert(me->commit_idx <= idx);
@@ -119,18 +119,18 @@ void raft_set_commit_idx(raft_server_t* me_, int idx)
     me->commit_idx = idx;
 }
 
-void raft_set_last_applied_idx(raft_server_t* me_, int idx)
+void raft_set_last_applied_idx(raft_server_t* me_, raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     me->last_applied_idx = idx;
 }
 
-int raft_get_last_applied_idx(raft_server_t* me_)
+raft_index_t raft_get_last_applied_idx(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->last_applied_idx;
 }
 
-int raft_get_commit_idx(raft_server_t* me_)
+raft_index_t raft_get_commit_idx(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->commit_idx;
 }
@@ -149,7 +149,7 @@ int raft_get_state(raft_server_t* me_)
     return ((raft_server_private_t*)me_)->state;
 }
 
-raft_node_t* raft_get_node(raft_server_t *me_, int nodeid)
+raft_node_t* raft_get_node(raft_server_t *me_, raft_node_id_t nodeid)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
@@ -173,13 +173,13 @@ raft_node_t* raft_get_my_node(raft_server_t *me_)
     return NULL;
 }
 
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const int idx)
+raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->nodes[idx];
 }
 
-int raft_get_current_leader(raft_server_t* me_)
+raft_node_id_t raft_get_current_leader(raft_server_t* me_)
 {
     raft_server_private_t* me = (void*)me_;
     if (me->current_leader)
@@ -213,9 +213,9 @@ int raft_is_candidate(raft_server_t* me_)
     return raft_get_state(me_) == RAFT_STATE_CANDIDATE;
 }
 
-int raft_get_last_log_term(raft_server_t* me_)
+raft_term_t raft_get_last_log_term(raft_server_t* me_)
 {
-    int current_idx = raft_get_current_idx(me_);
+    raft_index_t current_idx = raft_get_current_idx(me_);
     if (0 < current_idx)
     {
         raft_entry_t* ety = raft_get_entry_from_idx(me_, current_idx);
@@ -243,17 +243,17 @@ raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_)
     return log_get_at_idx(me->log, raft_get_last_applied_idx(me_));
 }
 
-int raft_get_snapshot_last_idx(raft_server_t *me_)
+raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_)
 {
     return ((raft_server_private_t*)me_)->snapshot_last_idx;
 }
 
-int raft_get_snapshot_last_term(raft_server_t *me_)
+raft_term_t raft_get_snapshot_last_term(raft_server_t *me_)
 {
     return ((raft_server_private_t*)me_)->snapshot_last_term;
 }
 
-void raft_set_snapshot_metadata(raft_server_t *me_, int term, int idx)
+void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     me->snapshot_last_term = term;

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -16,7 +16,7 @@ static int __logentry_get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int ety_idx
+    raft_index_t ety_idx
     )
 {
     return 0;
@@ -26,7 +26,7 @@ static int __log_offer(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    raft_index_t entry_idx
     )
 {
     CuAssertIntEquals((CuTest*)raft, 1, entry_idx);
@@ -37,7 +37,7 @@ static int __log_pop(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    raft_index_t entry_idx
     )
 {
     raft_entry_t* copy = malloc(sizeof(*entry));
@@ -50,7 +50,7 @@ static int __log_pop_failing(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx
+    raft_index_t entry_idx
     )
 {
     return -1;

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -14,7 +14,7 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
+    raft_term_t term,
     int vote
     )
 {

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -17,7 +17,7 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
+    raft_term_t term,
     int vote
     )
 {
@@ -37,7 +37,7 @@ int __raft_applylog(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return 0;
@@ -47,7 +47,7 @@ int __raft_applylog_shutdown(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return RAFT_ERR_SHUTDOWN;
@@ -291,7 +291,7 @@ static int __raft_logentry_offer(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int ety_idx
+    raft_index_t ety_idx
     )
 {
     CuAssertIntEquals(udata, ety_idx, 1);
@@ -1516,14 +1516,14 @@ typedef enum {
 
 typedef struct {
     __raft_error_type_e type;
-    int idx;
+    raft_index_t idx;
 } __raft_error_t;
 
 static int __raft_log_offer_error(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx)
+    raft_index_t entry_idx)
 {
     __raft_error_t *error = user_data;
 
@@ -1536,7 +1536,7 @@ static int __raft_log_pop_error(
     raft_server_t* raft,
     void *user_data,
     raft_entry_t *entry,
-    int entry_idx)
+    raft_index_t entry_idx)
 {
     __raft_error_t *error = user_data;
 

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -14,7 +14,7 @@
 static int __raft_persist_term(
     raft_server_t* raft,
     void *udata,
-    int term,
+    raft_term_t term,
     int vote
     )
 {
@@ -34,7 +34,7 @@ static int __raft_applylog(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
-    int idx
+    raft_index_t idx
     )
 {
     return 0;


### PR DESCRIPTION
For example, something like
```
typedef unsigned long int raft_term_t;
typedef unsigned long int raft_index_t;
```

The main advantage here is to make it possible to easily switch from the current 32-bit (int) implementation to 64 bit (long on x86_64).