### PR TITLE
Remove erronous(?) assertion on compaction.

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1325,8 +1325,6 @@ int raft_end_snapshot(raft_server_t *me_)
         }
     }
 
-    assert(raft_get_log_count(me_) == 1);
-
     return 0;
 }
 


### PR DESCRIPTION
@willemt I am not entirely sure about it as I did not track the latest snapshot fixes.  After merging the latest changes I started hitting this assert (because the log is empty after end_snapshot, as expected when last entry is committed).

My guess is it was masked by another issue which was recently solved, but you may know better.
