### PR TITLE
End snapshot fixes.

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1285,11 +1285,10 @@ int raft_end_snapshot(raft_server_t *me_)
         return -1;
 
     assert(raft_get_num_snapshottable_logs(me_) != 0);
-    assert(me->snapshot_last_idx == raft_get_commit_idx(me_));
 
     /* If needed, remove compacted logs */
-    raft_index_t i = 0, end = raft_get_num_snapshottable_logs(me_);
-    for (; i < end; i++)
+    raft_index_t i = log_get_base(me->log) + 1, end = me->snapshot_last_idx;
+    for (; i <= end; i++)
     {
         raft_entry_t* _ety;
         int e = raft_poll_entry(me_, &_ety);


### PR DESCRIPTION
We can't assume commit index does not change between begin and end
snapshot, as AE responses may arrive.