### PR TITLE
Add raft_cancel_snapshot().

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -821,6 +821,16 @@ int raft_begin_snapshot(raft_server_t *me_);
  **/
 int raft_end_snapshot(raft_server_t *me_);
 
+/** Cancel snapshotting.
+ *
+ * If an error occurs during snapshotting, this function can be called instead
+ * of raft_end_snapshot() to cancel the operation.
+ *
+ * The user MUST be sure the original snapshot is left untouched and remains
+ * usable.
+ */
+int raft_cancel_snapshot(raft_server_t *me_);
+
 /** Get the entry index of the entry that was snapshotted
  **/
 raft_index_t raft_get_snapshot_entry_idx(raft_server_t *me_);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -77,6 +77,12 @@ typedef struct {
     /* Last compacted snapshot */
     raft_index_t snapshot_last_idx;
     raft_term_t snapshot_last_term;
+
+    /* Previous index/term values stored during snapshot,
+     * which are restored if the operation is cancelled.
+     */
+    raft_index_t saved_snapshot_last_idx;
+    raft_term_t saved_snapshot_last_term;
 } raft_server_private_t;
 
 int raft_election_start(raft_server_t* me);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1277,6 +1277,21 @@ int raft_begin_snapshot(raft_server_t *me_)
     return 0;
 }
 
+int raft_cancel_snapshot(raft_server_t *me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    if (!me->snapshot_in_progress)
+        return -1;
+
+    me->snapshot_last_idx = me->saved_snapshot_last_idx;
+    me->snapshot_last_term = me->saved_snapshot_last_term;
+
+    me->snapshot_in_progress = 1;
+
+    return 0;
+}
+
 int raft_end_snapshot(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1287,7 +1287,7 @@ int raft_cancel_snapshot(raft_server_t *me_)
     me->snapshot_last_idx = me->saved_snapshot_last_idx;
     me->snapshot_last_term = me->saved_snapshot_last_term;
 
-    me->snapshot_in_progress = 1;
+    me->snapshot_in_progress = 0;
 
     return 0;
 }
@@ -1339,8 +1339,6 @@ int raft_end_snapshot(raft_server_t *me_)
                 me->cb.send_snapshot(me_, me->udata, node);
         }
     }
-
-    assert(raft_get_log_count(me_) == 1);
 
     return 0;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -256,6 +256,8 @@ raft_term_t raft_get_snapshot_last_term(raft_server_t *me_)
 void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->saved_snapshot_last_term = me->snapshot_last_term;
+    me->saved_snapshot_last_idx = me->snapshot_last_idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;
 }


### PR DESCRIPTION
This cancels the snapshot operation and reverts back to the state we
were in before raft_begin_snapshot().

It is useful for cases where the snapshot operation fails.  It is the
caller's responsibility to make sure the FSM state remains intact of
course.