### PR TITLE
Allow entries to apply during snapshot

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -39,6 +39,9 @@ typedef enum {
     RAFT_STATE_LEADER
 } raft_state_e;
 
+/** Allow entries to apply while taking a snapshot */
+#define RAFT_SNAPSHOT_NONBLOCKING_APPLY     1
+
 typedef enum {
     /**
      * Regular log type.
@@ -800,10 +803,14 @@ int raft_entry_is_cfg_change(raft_entry_t* ety);
  *  - not apply log entries
  *  - not start elections
  *
+ * If the RAFT_SNAPSHOT_NONBLOCKING_APPLY flag is specified, log entries will
+ * be applied during snapshot.  The FSM must isolate the snapshot state and
+ * guarantee these changes do not affect it.
+ *
  * @return 0 on success
  *
  **/
-int raft_begin_snapshot(raft_server_t *me_);
+int raft_begin_snapshot(raft_server_t *me_, int flags);
 
 /** Stop snapshotting.
  *
@@ -828,6 +835,11 @@ raft_index_t raft_get_snapshot_entry_idx(raft_server_t *me_);
 /** Check is a snapshot is in progress
  **/
 int raft_snapshot_is_in_progress(raft_server_t *me_);
+
+/** Check if entries can be applied now (no snapshot in progress, or
+ * RAFT_SNAPSHOT_NONBLOCKING_APPLY specified).
+ **/
+int raft_is_apply_allowed(raft_server_t* me_);
 
 /** Remove the first log entry.
  * This should be used for compacting logs.

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -73,6 +73,7 @@ typedef struct {
     int connected;
 
     int snapshot_in_progress;
+    int snapshot_flags;
 
     /* Last compacted snapshot */
     raft_index_t snapshot_last_idx;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -235,6 +235,12 @@ int raft_snapshot_is_in_progress(raft_server_t *me_)
     return ((raft_server_private_t*)me_)->snapshot_in_progress;
 }
 
+int raft_is_apply_allowed(raft_server_t* me_)
+{
+    return (!raft_snapshot_is_in_progress(me_) ||
+            (((raft_server_private_t*)me_)->snapshot_flags & RAFT_SNAPSHOT_NONBLOCKING_APPLY));
+}
+
 raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;


### PR DESCRIPTION
Currently `raft_apply_entry()` and `raft_apply_all()` will avoid applying entries if a snapshot is in progress.  Assuming the FSM is able to provide the proper isolation, I don't see any real reason to prevent this in the library but @willemt perhaps you do?

This requires care in maintaining the different indexes, but we anyway must assume the commit index can advance during snapshots (see #84 for example).