### PR TITLE
AE error response not properly handled.

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -312,8 +312,6 @@ int raft_recv_appendentries_response(raft_server_t* me_,
         assert(0 < next_idx);
         /* Stale response -- ignore */
         assert(match_idx <= next_idx - 1);
-        if (match_idx == next_idx - 1)
-            return 0;
         if (r->current_idx < next_idx - 1)
             raft_node_set_next_idx(node, min(r->current_idx + 1, raft_get_current_idx(me_)));
         else


### PR DESCRIPTION
Errors were ignored if node's match_idx==next_idx-1, I assume (??) as a
precaution against silently feeding a node that is not monotonic.

However this does not consider the case where send_appendentries()
relies on snapshot_last_idx which may be greater than the node's index.

@willemt can you think of unwanted side effects for this?