### PR TITLE
Fix memory leak on snapshot loading.

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1396,8 +1396,10 @@ int raft_begin_load_snapshot(
     {
         if (raft_get_nodeid(me_) == raft_node_get_id(me->nodes[i]))
             my_node_by_idx = i;
-        else
-            raft_node_set_active(me->nodes[i], 0);
+        else {
+            raft_node_free(me->nodes[i]);
+            me->nodes[i] = NULL;
+        }
     }
 
     /* this will be realloc'd by a raft_add_node */

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -682,7 +682,10 @@ void TestRaft_leader_sends_appendentries_with_correct_prev_log_idx_when_snapshot
     /* i'm leader */
     raft_set_state(r, RAFT_STATE_LEADER);
 
-    raft_node_t* p = raft_get_node_from_idx(r, 1);
+    /* reload node configuration; we expect the app to decode it from
+     * the loaded snapshot.
+     */
+    raft_node_t* p = raft_add_node(r, NULL, 2, 0);
     CuAssertTrue(tc, NULL != p);
     raft_node_set_next_idx(p, 4);
 


### PR DESCRIPTION
All nodes expect local should be removed when loading a snapshot, and
any prior knowledge about them should be void.