### PR TITLE
Fix a memory leak with log_clear.

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -407,6 +407,12 @@ typedef struct
      *  time to free the memory. */
     func_logentry_event_f log_pop;
 
+    /** Callback called for every existing log entry when clearing the log.
+     * If memory was malloc'd in log_offer and the entry doesn't get a chance
+     * to go through log_poll or log_pop, this is the last chance to free it.
+     */
+    func_logentry_event_f log_clear;
+
     /** Callback for determining which node this configuration log entry
      * affects. This call only applies to configuration change log entries.
      * @return the node ID of the node */

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -15,6 +15,8 @@ void log_free(log_t* me_);
 
 void log_clear(log_t* me_);
 
+void log_clear_entries(log_t* me_);
+
 /**
  * Add entry to log.
  * Don't add entry if we've already added this entry (based off ID)

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -79,6 +79,7 @@ int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term)
 {
     log_private_t* me = (log_private_t*)me_;
 
+    log_clear_entries(me_);
     log_clear(me_);
     me->base = idx;
 
@@ -120,6 +121,21 @@ void log_clear(log_t* me_)
     me->back = 0;
     me->front = 0;
     me->base = 0;
+}
+
+void log_clear_entries(log_t* me_)
+{
+    log_private_t* me = (log_private_t*)me_;
+    raft_index_t i;
+
+    if (!me->count || !me->cb || !me->cb->log_clear)
+        return;
+
+    for (i = me->base; i <= me->base + me->count; i++)
+    {
+        me->cb->log_clear(me->raft, raft_get_udata(me->raft),
+                          &me->entries[(me->front + i - me->base) % me->size], i);
+    }
 }
 
 /** TODO: rename log_append */

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -125,6 +125,7 @@ void raft_clear(raft_server_t* me_)
     me->last_applied_idx = 0;
     me->num_nodes = 0;
     me->node = NULL;
+    log_clear_entries(me->log);
     log_clear(me->log);
 }
 


### PR DESCRIPTION
This is probably most common when loading a snapshot.  Currently it is
only possibly to free allocated entry memory on log_pop and log_poll,
but neither are called on log_reset().

This is a quick and non-breaking fix.  A better but not backward
compatible option can be to have a free function callback as part of
the entry itself (automatically called when needed, not by log_pop or
log_poll).  This would also make it easier to avoid redundant buffer
allocs/copies on the app side.