### PR TITLE
DAOS-1406 build: Regenerate tests_main.c properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clinkedlistqueue:
 
 download-contrib: clinkedlistqueue
 
-$(TEST_DIR)/main_test.c:
+$(TEST_DIR)/main_test.c: $(TEST_DIR)/test_*.c
 	if test -d $(LLQUEUE_DIR); \
 	then echo have contribs; \
 	else make download-contrib; \
@@ -54,7 +54,7 @@ static: $(OBJECTS)
 	ar -r libraft.a $(OBJECTS)
 
 .PHONY: tests
-tests: src/raft_server.c src/raft_server_properties.c src/raft_log.c src/raft_node.c $(TEST_DIR)/main_test.c $(TEST_DIR)/test_server.c $(TEST_DIR)/test_node.c $(TEST_DIR)/test_log.c $(TEST_DIR)/test_snapshotting.c $(TEST_DIR)/test_scenario.c $(TEST_DIR)/mock_send_functions.c $(TEST_DIR)/CuTest.c $(LLQUEUE_DIR)/linked_list_queue.c
+tests: src/raft_server.c src/raft_server_properties.c src/raft_log.c src/raft_node.c $(TEST_DIR)/main_test.c $(TEST_DIR)/test_*.c $(TEST_DIR)/mock_send_functions.c $(TEST_DIR)/CuTest.c $(LLQUEUE_DIR)/linked_list_queue.c
 	$(CC) $(CFLAGS) -o tests_main $^
 	./tests_main
 	gcov raft_server.c


### PR DESCRIPTION
Makefile target $(TEST_DIR)/main_test.c should depend on
$(TEST_DIR)/test_*.c. Otherwise, when a new test is added to test_log.c,
for instance, main_test.c won't be regenerated to include the new test.

Signed-off-by: Li Wei <wei.g.li@intel.com>