### PR TITLE
fix potential null entry reference

### DIFF
--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -150,6 +150,9 @@ int log_append_entry(log_t* me_, raft_entry_t* ety)
         return e;
 
     memcpy(&me->entries[me->back], ety, sizeof(raft_entry_t));
+    /** copy the data buf */
+    me->entries[me->back].data.buf = malloc(ety->data.len);
+    memcpy(me->entries[me->back].data.buf, ety->data.buf, ety->data.len);
 
     if (me->cb && me->cb->log_offer)
     {


### PR DESCRIPTION
In function `log_append_entry`, the code directly copies the `raft_entry_t` into the entries log, which contains the pointer to the data buffer. 
Since every `append entries` request would create such entries, and not every time these entries would be appended into the log (e.g. they might be appended some time before). I would like to free these entries' memory possession. But free the  `raft_entry_t` would result in the null reference of the data buffer during the further call of `__raft_applylog` function. (since it directly copies the pointer, not the buffer itself)
So I think it's better to malloc and copy the data buffer in `log_append_entry` function, which would reduce the memory usage (otherwise there would be memory leak of the redundant call of `append entries`) as well as improve the understanding, since we don't assume anything of the `raft_entry_t`, so that it would be freed by the user after `append entries` function finished.