### PR TITLE
docs: fix raft_node_get_match_idx's comment

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -666,7 +666,7 @@ raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 raft_index_t raft_node_get_next_idx(raft_node_t* node);
 
 /**
- * @return this node's user data */
+ * @return this node's match index */
 raft_index_t raft_node_get_match_idx(raft_node_t* me);
 
 /**


### PR DESCRIPTION
In [include/raft.h](https://github.com/willemt/raft/blob/master/include/raft.h#L669)

The function `raft_node_get_match_idx`'s comment is wrong:

```c
/**
 * @return this node's user data */
raft_index_t raft_node_get_match_idx(raft_node_t* me);
```

It should be:

```c
/**
 * @return this node's match index */
raft_index_t raft_node_get_match_idx(raft_node_t* me);
```