### PR TITLE
only remove nodes from node list after removal is commited to removed node

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -776,6 +776,16 @@ void raft_node_set_voting(raft_node_t* node, int voting);
  * @return 1 if this is a voting node. Otherwise 0. */
 int raft_node_is_voting(raft_node_t* me_);
 
+/** Tell if node has been marked for removal
+ * @return 1 if this is a removed node, Otherwise 0. */
+int raft_node_is_removed(raft_node_t* me_);
+
+/** Turn a node into a removed node.
+ * neccessary to enable removing a node after an appendentry with an update commit idx is sent
+ * enabling removed node to know it was remvoed 
+ */
+void raft_node_set_removed(raft_node_t* me_);
+
 /** Check if a node has sufficient logs to be able to join the cluster.
  **/
 int raft_node_has_sufficient_logs(raft_node_t* me_);

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -190,3 +190,15 @@ int raft_node_is_addition_committed(raft_node_t* me_)
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
 }
+
+int raft_node_is_removed(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->removed;
+}
+
+void raft_node_set_removed(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->removed = 1;
+}

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -34,6 +34,8 @@ typedef struct
     int flags;
 
     raft_node_id_t id;
+
+    int removed;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -947,7 +947,7 @@ int raft_send_appendentries_all(raft_server_t* me_)
     int i, e;
 
     me->timeout_elapsed = 0;
-    for (i = 0; i < me->num_nodes; i++)
+    for (i = me->num_nodes - 1; i >= 0; i--)
     {
         if (me->node == me->nodes[i] || !raft_node_is_active(me->nodes[i]))
             continue;


### PR DESCRIPTION
currently, the leader removes the node from its list of nodes as soon as it commits its own log entry.

what this means, is that the removed node will never commit the log entry of removal.  this seems wrong to me.

I've modified the code to mark the node removed on commit to leader, but only actually remove the node after appendentries_all (i.e. with updated commit idx) is sent succesfully to the node

It's possible, that this is problematic.  i.e. what happens if node is dead (so can't send message).  open to better logic for determining when to remvoe node